### PR TITLE
Allow perf secondaries / better error if you try to use one

### DIFF
--- a/vault_entity_alias_mount_mapping.py
+++ b/vault_entity_alias_mount_mapping.py
@@ -16,8 +16,8 @@ import logging
 import argparse
 from looseversion import LooseVersion
 from EnvDefault import env_default
-import pprint
-version = '0.0.5'
+
+version = '0.0.6'
 
 minimum_vault_version = "1.11"
 


### PR DESCRIPTION
While taking this script for a test drive, I received a cryptic error:
```
 (vault-entities) @arlo ~/repos/vault_entity_alias_mount_mapping $ ./vault_entity_alias_mount_mapping.py --vault_token $(vault print token)
2024-06-20 13:04:14 EDT: Starting vault_entity_alias_mount_mapping.py
2024-06-20 13:04:14 EDT: vault_addr: http://spud:8200
2024-06-20 13:04:14 EDT: Start time: 1 years ago
2024-06-20 13:04:14 EDT: 'Response' object is not subscriptable
2024-06-20 13:04:14 EDT: [error]: Unable to read Vault health.
```
What I discovered is that I had my `VAULT_ADDR` set to a perf standby node of my cluster. Digging further, I discovered that the HVAC library [passes the parsed JSON through for 200 responses, but the full requests.Response object for non-200 responses](https://github.com/hvac/hvac/blob/main/hvac/adapters.py#L383).

I find this behavior from a library very frustrating, and was the source of that cryptic error - for HTTP code 473 the read_health_status method returned a requests.Response object, not a dict, so the subscript operations failed.

1. Since you can read entity data from a perf standby, I think it's an improvement to explicitly allow this via the `performance_standby_code` option to the method.
1. Additionally, if there is a different type of non-200 response, I think the additional error handling code here improves the experience. But I'm less attached to that  change than the first one.